### PR TITLE
Support byte[] payloads of type x-spring-tuple

### DIFF
--- a/spring-cloud-starter-stream-sink-log/src/main/java/org/springframework/cloud/stream/app/log/sink/LogSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-log/src/main/java/org/springframework/cloud/stream/app/log/sink/LogSinkConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.messaging.MessageHeaders;
  * @author Gary Russell
  * @author Chris Schaefer
  * @author Soby Chacko
+ * @author Christian Tzolov
  */
 @EnableBinding(Sink.class)
 @EnableConfigurationProperties(LogSinkProperties.class)
@@ -53,7 +54,7 @@ public class LogSinkConfiguration {
 					String contentType = message.getHeaders().containsKey(MessageHeaders.CONTENT_TYPE)
 							? message.getHeaders().get(MessageHeaders.CONTENT_TYPE).toString()
 							: BindingProperties.DEFAULT_CONTENT_TYPE.toString();
-					if (contentType.contains("text") || contentType.contains("json")) {
+					if (contentType.contains("text") || contentType.contains("json") || contentType.contains("x-spring-tuple")) {
 						message = new MutableMessage<>(new String(((byte[]) message.getPayload())), message.getHeaders());
 					}
 				}


### PR DESCRIPTION
To produce correct text output, the Log Sink is required to turn
any byte-encoded payloads of text type (such as text to json) back into strings.
This is implemented for `text` and `json` content-types and needs to be extended
for byte encoded Tuple payloads with `x-spring-tuple` content type header.
    
Tuple objects can be serialized ONLY by the TupleJsonMessageConverter.
The ApplicationJsonMessageMarshallingConverter fails to serialize Tuples
because the DefaultTuple contains non-serializable fields such as
configurableConversionService.
    
While TupleJsonMessageConverter supports `application/json` types its preceding lays below
the ApplicationJsonMessageMarshallingConverter in the list of pre-configured default
converters (CompositeMessageConverterFactory).
    
Therefore a Tuple payload outbound message with `application/json` content-type header
 is matched by the ApplicationJsonMessageMarshallingConverter and fails to convert.
    
To handle the outbound messages to the TupleJsonMessageConverter the they
 must use the `x-spring-tuple` content-type.
    
The TupleJsonMessageConverter converts the Tuple into a json message and encodes as byte array.
    
Note that the older TupleJsonMessageConverter 1.x versions encode the payload as string and
don't require special handling by the Log Sink.
    
Resolves #9
Related-To #7 